### PR TITLE
No fetches

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,4 @@ rustdoc-args = [
 ]
 
 [workspace]
-members = [
-    "embed-trait-info",
-]
+members = ["embed-trait-info"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,8 @@ rustdoc-args = [
     "--html-after-content",
     "docs-rs/trait-tags.html",
 ]
+
+[workspace]
+members = [
+    "embed-trait-info",
+]

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ See [`Cargo.toml`](./Cargo.toml) for the configuration passed to [docs.rs] for b
 
 This extension adds tags on types to indicate usage based on Bevy traits such as `Component`, `Event`, etc.
 
-For trait tags to show in listings, metadata needs to be embedded withing the source files. You likely do not want to commit this to version control on a branch that receives new manual changes.
+For trait tags to show in listings, metadata needs to be embedded within the source files. You likely do not want to commit this to version control on a branch that receives new manual changes.
 Run the `embed-trait-info` tool and point it at your project workspace, e.g.
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -48,10 +48,10 @@ See [`Cargo.toml`](./Cargo.toml) for the configuration passed to [docs.rs] for b
 This extension adds tags on types to indicate usage based on Bevy traits such as `Component`, `Event`, etc.
 
 For trait tags to show in listings, metadata needs to be embedded within the source files. You likely do not want to commit this to version control on a branch that receives new manual changes.
-Run the `embed-trait-info` tool and point it at your project workspace, e.g.
+Run the `embed-trait-info` tool by pointing it at your project workspace (using `--root-dir` if it doesn't match the working directors) and give it the names of the packages to modify, e.g.
 
 ```bash
-embed-trait-info my_crate
+cargo run -p embed-trait-info bevy_docs_extension_demo
 ```
 
 before building the documentation as above.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ See [`Cargo.toml`](./Cargo.toml) for the configuration passed to [docs.rs] for b
 [`rustdoc` documentation]: https://doc.rust-lang.org/rustdoc/command-line-arguments.html
 [Bevy game engine]: https://bevyengine.org
 
-## Trait tags
+## Trait Tags
 
 This extension adds tags on types to indicate usage based on Bevy traits such as `Component`, `Event`, etc.
 

--- a/README.md
+++ b/README.md
@@ -22,8 +22,6 @@ you must provide absolute paths instead of relative paths for files:
 RUSTDOCFLAGS="--html-after-content path/to/docs-rs/trait-tags.html" cargo doc
 ```
 
-You can then serve the documentation with a web server like [http-server](https://lib.rs/crates/http-server).
-
 ## Building on Docs.rs
 
 Extensions can be applied to [docs.rs] builds by providing the relevant arguments
@@ -44,6 +42,19 @@ See [`Cargo.toml`](./Cargo.toml) for the configuration passed to [docs.rs] for b
 [rustdoc]: https://doc.rust-lang.org/rustdoc/what-is-rustdoc.html
 [`rustdoc` documentation]: https://doc.rust-lang.org/rustdoc/command-line-arguments.html
 [Bevy game engine]: https://bevyengine.org
+
+## Trait tags
+
+This extension adds tags on types to indicate usage based on Bevy traits such as `Component`, `Event`, etc.
+
+For trait tags to show in listings, metadata needs to be embedded withing the source files. You likely do not want to commit this to version control on a branch that receives new manual changes.
+Run the `embed-trait-info` tool and point it at your project workspace, e.g.
+
+```bash
+embed-trait-info/target/release/embed-trait-info .
+```
+
+before building the documentation as above.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ For trait tags to show in listings, metadata needs to be embedded withing the so
 Run the `embed-trait-info` tool and point it at your project workspace, e.g.
 
 ```bash
-embed-trait-info/target/release/embed-trait-info .
+embed-trait-info my_crate
 ```
 
 before building the documentation as above.

--- a/docs-rs/trait-tags.html
+++ b/docs-rs/trait-tags.html
@@ -126,32 +126,35 @@
         return el;
     }
 
-    // For item listings in modules, sort the items by implemented Bevy
-    // traits and add corresponding tags.
-    // Send off all network requests simultaneously.
-    for (const kind of ['structs', 'enums', 'functions']) {
-        // Find the listing
-        let heading = document.getElementById(kind);
-        if (!heading) {
-            continue
-        }
-        const listing = heading.nextSibling;
-        const items = [];
-        for (const item of listing.children) {
-            // Only look at items, not their description
-            if (item.nodeName != "DT") {
+    const info_node = document.getElementById("bevy-traits-data");
+
+    if (info_node) {
+        const info = JSON.parse(info_node.innerText);
+
+        // For item listings in modules, sort the items by implemented Bevy
+        // traits and add corresponding tags.
+        // Send off all network requests simultaneously.
+        for (const kind of ['structs', 'enums', 'functions']) {
+            // Find the listing
+            let heading = document.getElementById(kind);
+            if (!heading) {
                 continue
             }
-            let url = item.firstChild.href;
-            items.push(
-                getBevyTraitsForUrl(url).then(
-                    (traits) => ({element: item, traits: traits})
-                )
-            );
+            const listing = heading.nextSibling;
+            const items = [];
+            for (const item of listing.children) {
+                // Only look at items, not their description
+                if (item.nodeName != "DT") {
+                    continue
+                }
+                let url = item.firstChild.href;
+                let name_end = url.lastIndexOf(".");
+                let name_start = url.lastIndexOf(".", name_end - 1) + 1;
+                let name = url.substring(name_start, name_end);
+                items.push({element: item, traits: new Set(info[name])});
+            }
+            applyTagsToItems(items);
         }
-        Promise.all(items).then(
-            (items) => applyTagsToItems(items)
-        );
     }
 
     // See what Bevy traits the type whose doc page this url points to implements.

--- a/docs-rs/trait-tags.html
+++ b/docs-rs/trait-tags.html
@@ -129,7 +129,11 @@
     const info_node = document.getElementById("bevy-traits-data");
 
     if (info_node) {
-        const info = JSON.parse(info_node.innerText);
+        const data_uri = info_node.href;
+        const base64_index = data_uri.indexOf(",") + 1;
+        const base64 = data_uri.substring(base64_index);
+        const json = atob(base64)
+        const info = JSON.parse(json);
 
         // For item listings in modules, sort the items by implemented Bevy
         // traits and add corresponding tags.

--- a/docs-rs/trait-tags.html
+++ b/docs-rs/trait-tags.html
@@ -137,7 +137,6 @@
 
         // For item listings in modules, sort the items by implemented Bevy
         // traits and add corresponding tags.
-        // Send off all network requests simultaneously.
         for (const kind of ['structs', 'enums', 'functions']) {
             // Find the listing
             let heading = document.getElementById(kind);

--- a/embed-trait-info/.gitignore
+++ b/embed-trait-info/.gitignore
@@ -1,0 +1,2 @@
+/target
+/Cargo.lock

--- a/embed-trait-info/Cargo.toml
+++ b/embed-trait-info/Cargo.toml
@@ -4,5 +4,6 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+base64 = "0.22.1"
 rustdoc-types = "0.35"
 serde_json = "1"

--- a/embed-trait-info/Cargo.toml
+++ b/embed-trait-info/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-base64 = "0.22.1"
+base64 = "0.22"
+clap = { version = "4.0", features = ["derive"] }
 rustdoc-types = "0.35"
 serde_json = "1"

--- a/embed-trait-info/Cargo.toml
+++ b/embed-trait-info/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "embed-trait-info"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+rustdoc-types = "0.35"
+serde_json = "1"

--- a/embed-trait-info/src/bin/main.rs
+++ b/embed-trait-info/src/bin/main.rs
@@ -1,0 +1,18 @@
+use clap::Parser;
+
+/// Modify source files by embedding metadata needed for trait tags in item listings.
+#[derive(Parser, Debug)]
+struct Args {
+    #[arg(long, default_value = ".")]
+    /// Workspace root directory
+    root_dir: String,
+
+    #[arg(num_args(1..))]
+    /// Names of packages to modify in
+    packages: Vec<String>,
+}
+
+fn main() {
+    let args = Args::parse();
+    embed_trait_info::run(&args.root_dir, args.packages);
+}

--- a/embed-trait-info/src/lib.rs
+++ b/embed-trait-info/src/lib.rs
@@ -26,7 +26,7 @@ pub fn run(root_dir: &str, packages: Vec<String>) {
 fn add_info_to_package_source(root_dir: &str, package: &str) {
     let root_dir = PathBuf::from(root_dir);
     let file_name = root_dir.join(format!("target/doc/{package}.json"));
-    let file = match File::open(&file_name).expect() {
+    let file = match File::open(&file_name) {
         Ok(file) => file,
         Err(e) => panic!("failed to open {file_name:?}: {e}"),
     };

--- a/embed-trait-info/src/main.rs
+++ b/embed-trait-info/src/main.rs
@@ -18,20 +18,6 @@ fn main() {
     run(root_dir, package_names(root_dir));
 }
 
-fn run(root_dir: &str, packages: Vec<String>) {
-    // Generate documentation as json
-    Command::new("cargo")
-        .args(["doc", "--all-features", "--workspace"])
-        .env("RUSTDOCFLAGS", "-Z unstable-options --output-format json")
-        .current_dir(root_dir)
-        .status()
-        .expect("Failed to run cargo doc in {root_dir}");
-
-    for package in packages {
-        add_info_to_package_source(root_dir, &package);
-    }
-}
-
 // Can be removed when this gets run by Bevy's publish.sh,
 // as that knows the precise list of crates to publish.
 fn package_names(root_dir: &str) -> Vec<String> {
@@ -54,6 +40,20 @@ fn package_names(root_dir: &str) -> Vec<String> {
         .collect()
 }
 
+fn run(root_dir: &str, packages: Vec<String>) {
+    // Generate documentation as json
+    Command::new("cargo")
+        .args(["doc", "--all-features", "--workspace"])
+        .env("RUSTDOCFLAGS", "-Z unstable-options --output-format json")
+        .current_dir(root_dir)
+        .status()
+        .expect("Failed to run cargo doc in {root_dir}");
+
+    for package in packages {
+        add_info_to_package_source(root_dir, &package);
+    }
+}
+
 fn add_info_to_package_source(root_dir: &str, package: &str) {
     let root_dir = PathBuf::from(root_dir);
     let file_name = root_dir.join(format!("target/doc/{package}.json"));
@@ -66,7 +66,6 @@ fn add_info_to_package_source(root_dir: &str, package: &str) {
         }
     };
     let crate_doc: Crate = serde_json::from_reader(file).unwrap();
-    assert_eq!(crate_doc.format_version, 39);
 
     for (module_span, info) in info_for_modules(&crate_doc) {
         let source_file = root_dir.join(&module_span.filename);

--- a/embed-trait-info/src/main.rs
+++ b/embed-trait-info/src/main.rs
@@ -1,0 +1,167 @@
+use std::{
+    collections::{HashMap, HashSet},
+    fs::{read_to_string, File},
+    path::PathBuf,
+    process::Command,
+    sync::LazyLock,
+};
+
+use rustdoc_types::{Crate, Item, ItemEnum, Span};
+
+fn main() {
+    // Temporary entrypoint, to be replaced if this is integrated in the CI tool
+    let args = std::env::args().collect::<Vec<_>>();
+    assert!(args.len() <= 2);
+    let root_dir = args.get(1).map_or(".", |s| s);
+
+    run(root_dir, package_names(root_dir));
+}
+
+fn run(root_dir: &str, packages: Vec<String>) {
+    // Generate documentation as json
+    Command::new("cargo")
+        .args(["doc", "--all-features", "--workspace"])
+        .env("RUSTDOCFLAGS", "-Z unstable-options --output-format json")
+        .current_dir(root_dir)
+        .status()
+        .expect("Failed to run cargo doc in {root_dir}");
+
+    for package in packages {
+        add_info_to_package_source(root_dir, &package);
+    }
+}
+
+// Can be removed when this gets run by Bevy's publish.sh,
+// as that knows the precise list of crates to publish.
+fn package_names(root_dir: &str) -> Vec<String> {
+    let output = Command::new("cargo")
+        .args(["metadata", "--no-deps", "--format-version", "1"])
+        .current_dir(root_dir)
+        .output()
+        .unwrap();
+    if !output.status.success() {
+        panic!("Failed to read manifest");
+    }
+    let manifest = serde_json::from_slice::<serde_json::Value>(&output.stdout).unwrap();
+    manifest
+        .get("packages")
+        .unwrap()
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|package| package.get("name").unwrap().as_str().unwrap().to_owned())
+        .collect()
+}
+
+fn add_info_to_package_source(root_dir: &str, package: &str) {
+    let root_dir = PathBuf::from(root_dir);
+    let file_name = root_dir.join(format!("target/doc/{package}.json"));
+    let file = match File::open(&file_name) {
+        Ok(file) => file,
+        Err(e) => {
+            // When we have a precise list of crates, this can just be turned into a panic
+            eprintln!("failed to open {file_name:?}: {e}");
+            return;
+        }
+    };
+    let crate_doc: Crate = serde_json::from_reader(file).unwrap();
+    assert_eq!(crate_doc.format_version, 39);
+
+    for (module_span, info) in info_for_modules(&crate_doc) {
+        let source_file = root_dir.join(&module_span.filename);
+        let src = read_to_string(&source_file).unwrap();
+        let pos = position_in_string(&src, module_span.begin);
+
+        // Insert data about implemented traits as a doc comment.
+        // The cfg prevents this from showing up in rust-analyzer,
+        // the css prevents this from being visible on the web (including to screen readers),
+        // and the id lets the ECMAScript find the data.
+        let new_src = format!(
+            r#"
+            {}
+            #![cfg_attr(doc, doc = "<div id=\"bevy-traits-data\" style=\"display:none\">{}</div>")]
+            {}
+            "#,
+            src[..pos].to_owned(),
+            serde_json::to_string(&info).unwrap().replace('"', "\\\""),
+            &src[pos..]
+        );
+
+        std::fs::write(source_file, new_src).unwrap();
+    }
+}
+
+/// Find the byte index into the string.
+/// Line is 1-based, column is 0-based.
+fn position_in_string(str: &str, (line, column): (usize, usize)) -> usize {
+    let mut pos = 0;
+    for _ in 1..line {
+        pos += str[pos..].find('\n').unwrap();
+    }
+    pos + column
+}
+
+type BevyTraits<'a> = Vec<&'a str>;
+type ModuleInfo<'a> = HashMap<&'a str, BevyTraits<'a>>;
+
+fn info_for_modules(crate_doc: &Crate) -> Vec<(&Span, ModuleInfo)> {
+    let mut modules = Vec::new();
+    for item in crate_doc.index.values() {
+        let ItemEnum::Module(module) = &item.inner else {
+            continue;
+        };
+        let Some(mod_span) = &item.span else { continue };
+        let items: ModuleInfo = module
+            .items
+            .iter()
+            .flat_map(|id| {
+                let item = &crate_doc.index[id];
+                let bevy_traits = bevy_traits_for_item(crate_doc, item);
+                (!bevy_traits.is_empty()).then(|| (item.name.as_deref().unwrap(), bevy_traits))
+            })
+            .collect();
+        if !items.is_empty() {
+            modules.push((mod_span, items));
+        }
+    }
+    modules
+}
+
+fn bevy_traits_for_item<'a>(crate_doc: &'a Crate, item: &Item) -> BevyTraits<'a> {
+    let impls = match &item.inner {
+        ItemEnum::Struct(def) => &def.impls,
+        ItemEnum::Enum(def) => &def.impls,
+        ItemEnum::Union(def) => &def.impls,
+        _ => return Vec::new(),
+    };
+    let mut traits = Vec::new();
+    for impl_id in impls {
+        let ItemEnum::Impl(impl_block) = &crate_doc.index[impl_id].inner else {
+            panic!()
+        };
+        if let Some(trait_) = &impl_block.trait_ {
+            let trait_name = trait_.path.as_str();
+            if BEVY_TRAITS.contains(trait_name) {
+                traits.push(trait_name);
+            }
+        }
+    }
+    traits
+}
+
+static BEVY_TRAITS: LazyLock<HashSet<String>> = LazyLock::new(|| {
+    [
+        "Plugin",
+        "PluginGroup",
+        "Component",
+        "Resource",
+        "Asset",
+        "Event",
+        "ScheduleLabel",
+        "SystemSet",
+        "SystemParam",
+    ]
+    .iter()
+    .map(|s| s.to_string())
+    .collect()
+});


### PR DESCRIPTION
Because currently the page of every listing item needs to fetched, listing items shift around after a delay. Fix this by embedding the necessary data in the module doc.

TODO: Should this also be done for the doc page of the types themselves? Would be more consistent (single source of truth) but miss out on types defined via macros.