### PR TITLE
Simplify metadata embedding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ readme = "README.md"
 bevy = "0.15"
 
 [package.metadata.docs.rs]
+rustc-args = ["--cfg", "docsrs_dep"]
 rustdoc-args = [
     # Embed tags to the top of documentation pages for common Bevy traits
     # that are implemented by the current type, like `Component` or `Resource`.
@@ -20,6 +21,9 @@ rustdoc-args = [
     "--html-after-content",
     "docs-rs/trait-tags.html",
 ]
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(docsrs_dep)'] }
 
 [workspace]
 members = ["embed-trait-info"]

--- a/README.md
+++ b/README.md
@@ -12,14 +12,14 @@ For example, building the docs with the `trait-tags` extension and `--no-deps` c
 with the following command:
 
 ```bash
-RUSTDOCFLAGS="--html-after-content docs-rs/trait-tags.html" cargo doc --no-deps
+RUSTDOCFLAGS="--html-after-content docs-rs/trait-tags.html --cfg docsrs_dep" RUSTFLAGS="--cfg docsrs_dep" cargo doc --no-deps
 ```
 
 Note that if documentation is also built for other dependencies,
 you must provide absolute paths instead of relative paths for files:
 
 ```bash
-RUSTDOCFLAGS="--html-after-content path/to/docs-rs/trait-tags.html" cargo doc
+RUSTDOCFLAGS="--html-after-content /path/to/docs-rs/trait-tags.html --cfg docsrs_dep" RUSTFLAGS="--cfg docsrs_dep" cargo doc
 ```
 
 ## Building on Docs.rs

--- a/docs-rs/trait-tags.html
+++ b/docs-rs/trait-tags.html
@@ -160,15 +160,6 @@
         }
     }
 
-    // See what Bevy traits the type whose doc page this url points to implements.
-    // Rejects in case of network error.
-    async function getBevyTraitsForUrl(url) {
-        const response = await fetch(url);
-        const fetched = await response.text();
-        const doc = new DOMParser().parseFromString(fetched, 'text/html');
-        return findImplementedBevyTraits(doc);
-    }
-
     // Sort the items in the DOM and apply tags
     function applyTagsToItems(items) {
         for (const item of items.toSorted(compareByTraits)) {

--- a/docs-rs/trait-tags.html
+++ b/docs-rs/trait-tags.html
@@ -129,11 +129,7 @@
     const info_node = document.getElementById("bevy-traits-data");
 
     if (info_node) {
-        const data_uri = info_node.href;
-        const base64_index = data_uri.indexOf(",") + 1;
-        const base64 = data_uri.substring(base64_index);
-        const json = atob(base64)
-        const info = JSON.parse(json);
+        const info = JSON.parse(info_node.innerText);
 
         // For item listings in modules, sort the items by implemented Bevy
         // traits and add corresponding tags.

--- a/embed-trait-info/Cargo.toml
+++ b/embed-trait-info/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-base64 = "0.22"
 clap = { version = "4.0", features = ["derive"] }
 rustdoc-types = "0.35"
 serde_json = "1"


### PR DESCRIPTION
I didn't think about using `RUSTFLAGS` to set a cfg flag for dependencies :3